### PR TITLE
Change bin command name to match package name

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/ai-fix.js",
   "bin": {
-    "ai-fix": "./dist/ai-fix.js"
+    "ai-writing-fix-cli": "./dist/ai-fix.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
fix: change bin command name to match package name

Changed bin field from "ai-fix" to "ai-writing-fix-cli" to ensure npx ai-writing-fix-cli works correctly when installed from npm

🤖 Generated with [Claude Code](https://claude.ai/code)